### PR TITLE
Update channel names, add heartbeat

### DIFF
--- a/ledwall.ino
+++ b/ledwall.ino
@@ -360,6 +360,12 @@ void onMqttMessage(int messageSize) {
 				}
 			}
 
+		} else if (strcmp(action, "ping") == 0) {
+			Serial.println("MQTT: Ping");
+			mqttClient.beginMessage("/ledwall/1/response");
+			mqttClient.print("{\"message\": \"ack\"}");
+			mqttClient.endMessage();
+
 		} else {
 			Serial.print("Unknown MQTT action: ");
 			Serial.println(action);
@@ -394,8 +400,11 @@ void setupWifi() {
 	}
 
 	mqttClient.onMessage(onMqttMessage);
-	mqttClient.subscribe("/ledwall/1/test");
+	mqttClient.subscribe("/ledwall/1/request");
 	Serial.println("MQTT connected");
+	mqttClient.beginMessage("/ledwall/1/response");
+	mqttClient.print("{\"message\": \"MQTT connected\"}");
+	mqttClient.endMessage();
 }
 
 void setup() {

--- a/protocol.yml
+++ b/protocol.yml
@@ -11,7 +11,7 @@ servers:
     protocol: MQTT
 
 channels:
-  /ledwall/1/test:
+  /ledwall/1/request:
     publish:
       operationId: ledwall
       message:
@@ -21,6 +21,12 @@ channels:
           - $ref: '#/components/messages/background'
           - $ref: '#/components/messages/brightness'
           - $ref: '#/components/messages/snake'
+
+  /ledwall/1/response:
+    subscribe:
+      operationId: ledwallack
+      message:
+        $ref: "#/components/messages/response"
 
 components:
   messages:
@@ -106,3 +112,12 @@ components:
           enabled:
             type: boolean
         required: ["action", "enabled"]
+
+    response:
+      description: Diagnostic and other feedback from the wall
+      payload:
+        type: object
+        properties:
+          message:
+            type: string
+        required: ["message"]


### PR DESCRIPTION
* Renamed existing `/ledwall/1/test` channel to `/ledwall/1/request` for data sent to the wall.
* Added new `/ledwall/1/response` channel for data coming back from the wall
* Wall announces when it's connected to Wifi and MQTT
* Added support for a ping request, with an ack response

Updated AsyncAPI description to match